### PR TITLE
Fix: Dynamic version loading and bump to v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2025-01-14
+
+### Fixed
+- CLI version display now correctly shows package.json version instead of hardcoded 0.1.0
+- Version is now dynamically loaded from package.json
+
 ## [0.2.0] - 2025-01-14
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "outlook-agent",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "CLI tool for managing Outlook calendar with mgc (Microsoft Graph CLI)",
   "bin": {
     "outlook-agent": "./dist/index.js"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,7 @@
 import { Command } from 'commander';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
 import { viewCalendar } from './commands/calendar/view.js';
 import { createEvent } from './commands/calendar/create.js';
 import { checkFreeBusy } from './commands/calendar/freebusy.js';
@@ -16,13 +19,18 @@ import { login } from './commands/auth/login.js';
 import { logout } from './commands/auth/logout.js';
 import { scheduleWeek } from './commands/agent/schedule-week.js';
 
+// Get package.json version dynamically
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageJson = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'));
+const version = packageJson.version;
+
 export function createCLI(): Command {
   const program = new Command();
   
   program
     .name('outlook-agent')
     .description('CLI tool for managing Outlook calendar')
-    .version('0.1.0');
+    .version(version);
 
   // カレンダーコマンドグループ
   const calendar = program


### PR DESCRIPTION
## 🚨 Critical Bug Fix - v0.2.1

### Problem
**v0.2.0 shows wrong version**: CLI was displaying hardcoded "0.1.0" instead of actual package version

### Root Cause
```typescript
// src/cli.ts - line 25
.version('0.1.0');  // ❌ Hardcoded version
```

### Solution
Load version dynamically from package.json:
```typescript
const packageJson = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'));
const version = packageJson.version;
.version(version);  // ✅ Dynamic version
```

### Changes
- `src/cli.ts` - Load version from package.json dynamically
- `package.json` - Bump version to 0.2.1
- `CHANGELOG.md` - Document the fix

### Verification
```bash
# After this fix
$ node dist/index.js --version
0.2.1  # ✅ Shows correct version
```

### Impact
Users who installed v0.2.0 see "0.1.0" when checking version, causing confusion about available features.

🤖 Generated with [Claude Code](https://claude.ai/code)