### PR TITLE
Enable manual workflow dispatch for releases

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -17,6 +17,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # Use PAT if available to trigger release workflow
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
       
       - name: Get version from package.json
         id: package-version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g., v0.2.1)'
+        required: true
+        type: string
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
Add manual trigger option for release workflow

## Changes
- Add `workflow_dispatch` trigger to release.yml
- Allows manual NPM releases from GitHub UI
- Useful when automatic tag trigger doesn't work

## Why needed
- GitHub Actions limitation: workflow-created tags don't trigger other workflows
- This provides a manual fallback option

🤖 Generated with [Claude Code](https://claude.ai/code)