### PR TITLE
Replace specific meeting name with generic example in AI instructions

### DIFF
--- a/prompts/ai-instructions.yaml
+++ b/prompts/ai-instructions.yaml
@@ -119,11 +119,11 @@ custom_rules:
   
   # コンフリクトとして扱わない組み合わせ
   ignore_conflicts:
-    - description: "金曜18時のToC EMよもやまとブロックは両立可能"
+    - description: "金曜18時のWeekly Team Syncとブロックは両立可能"
       conditions:
         - day_of_week: "Friday"
           time: "18:00"
-          event1_pattern: "toC EM よもやま"
+          event1_pattern: "Weekly Team Sync"
           event2_pattern: "ブロック"
       reason: "ブロックは参加可能な予備時間として設定されているため、実際のコンフリクトではない"
 


### PR DESCRIPTION
## Summary
- Replace "toC EM よもやま" with "Weekly Team Sync" in the `ignore_conflicts` example
- Makes the configuration example more universally applicable and generic

## Test plan
- [ ] Verify AI instructions still load correctly
- [ ] Confirm the ignore_conflicts rule still functions as expected with the new generic name

🤖 Generated with [Claude Code](https://claude.ai/code)