### PR TITLE
Fix release workflow for manual dispatch with tag validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Ensure tag exists for workflow_dispatch
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          TAG="${{ github.event.inputs.tag }}"
+          # Check if tag exists remotely
+          if git ls-remote --tags origin | grep -q "refs/tags/${TAG}$"; then
+            echo "Tag ${TAG} exists, checking out"
+            git checkout tags/${TAG}
+          else
+            echo "Error: Tag ${TAG} does not exist"
+            echo "Please create the tag first using: git tag ${TAG} && git push origin ${TAG}"
+            exit 1
+          fi
       
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -41,6 +57,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
+          tag_name: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Fixed release workflow to properly handle manual dispatch events
- Added tag existence validation before proceeding with release
- Ensured proper repository checkout with full history (fetch-depth: 0)
- Added proper tag_name configuration for manual releases

## Changes Made
- Enhanced `.github/workflows/release.yml` with tag validation step
- Added conditional logic to check tag existence when using workflow_dispatch
- Improved checkout configuration to fetch full git history
- Fixed tag_name parameter in the GitHub release action

## Test Plan
- [ ] Test manual workflow dispatch with existing tag
- [ ] Test manual workflow dispatch with non-existent tag (should fail gracefully)
- [ ] Verify automatic releases on tag push still work as expected
- [ ] Confirm release notes generation works properly

🤖 Generated with [Claude Code](https://claude.ai/code)