### PR TITLE
fix(deps): Node.js 22互換性問題を解決 (v0.3.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "outlook-agent",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "CLI tool for managing Outlook calendar with mgc (Microsoft Graph CLI)",
   "bin": {
     "outlook-agent": "./dist/index.js"
@@ -37,11 +37,9 @@
   "homepage": "https://github.com/chaspy/outlook-agent#readme",
   "dependencies": {
     "@ai-sdk/openai": "^0.0.30",
-    "@mastra/core": "^0.1.0",
     "ai": "^3.0.0",
     "chalk": "^5.3.0",
     "commander": "^11.1.0",
-    "crypto": "^1.0.1",
     "date-fns": "^3.0.6",
     "inquirer": "^9.2.12",
     "inquirer-autocomplete-prompt": "^3.0.1",


### PR DESCRIPTION
## 🐛 問題
v0.3.0でNode.js 22環境でのインストールエラーが発生

```
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: '@mastra/core@0.1.26',
npm warn EBADENGINE   required: { node: '>=20 <22' },
npm warn EBADENGINE   current: { node: 'v22.14.0', npm: '11.6.0' }
npm warn EBADENGINE }
npm warn deprecated crypto@1.0.1: This package is no longer supported.
```

## 🔧 修正内容

### 削除した依存関係
- **@mastra/core**: 実際のコードで未使用（ドキュメントのみ参照）
- **crypto@1.0.1**: 非推奨パッケージ（Node.js組み込みcryptoモジュールを使用）

### バージョン
- `0.3.0` → `0.3.1` (パッチリリース)

## ✅ テスト結果
- ✅ ビルド成功
- ✅ 既存機能に影響なし
- ✅ Node.js 22.x互換性確保

## 📦 影響
- インストールエラーの解決
- パッケージサイズの軽量化
- セキュリティ警告の除去

🤖 Generated with [Claude Code](https://claude.ai/code)